### PR TITLE
Don't error on Windows if cache dir already exists

### DIFF
--- a/ytsub.lua
+++ b/ytsub.lua
@@ -35,7 +35,7 @@ if not res or not res.is_dir then
         options.cache_dir = string.gsub(options.cache_dir, "/", "\\")
         command = {
             name = "subprocess",
-            args = {"cmd", "/c", "mkdir", options.cache_dir},
+            args = {"cmd", "/c", "if not exist", options.cache_dir, "mkdir", options.cache_dir},
             playback_only = false,
         }
     else


### PR DESCRIPTION
There is no `mkdir -p` equivalent on Windows, so the script will always try to create the cache dir. If it already exists, we an error in the logs:

```
[ytsub] A subdirectory or file C:\Users\mhyee\.cache\ytsub\ already exists.
```

This commit changes the command on Windows to create the cache dir only if it doesn't already exist.